### PR TITLE
Add go mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/iximiuz/ptyme
+
+go 1.13
+
+require golang.org/x/sys v0.0.0-20221010170243-090e33056c14

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Go modules has become the standard way to manage dependencies with Go so recent version of Go expect a `go.mod` file when using `go run`

This patch adds to hopefully help future users avoid errors that they might not know how to deal with:
```
$ make attach SOCK=localhost:43210
go run attach.go localhost:43210
attach.go:9:2: no required module provides package golang.org/x/sys/unix: go.mod file not 
found in current directory or any parent directory; see 'go help modules'
```